### PR TITLE
hide play Again button when in daily mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foclach",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/App.js
+++ b/src/App.js
@@ -584,6 +584,7 @@ function App() {
           shareResults={() => {
             copyToClipboard()
           }}
+          gameMode={gameMode}
           isOpen={modalIsOpen}
         ></EndGameButtons>
         <Keyboard

--- a/src/components/EndGameButtons.js
+++ b/src/components/EndGameButtons.js
@@ -1,7 +1,7 @@
 import { dictionary } from '../constants'
 
-const EndGameButtons = (props ) => {
-    const isVisible = props.isOpen
+const EndGameButtons = (props) => {
+    const isVisible = props.isOpen && !props.gameMode
     if (isVisible) {
         return <div className="endGameButtons">
         <button className="endGameButton"


### PR DESCRIPTION
Step to reproduce bug: 

1. Practice mode
2. Finish game & don't press the Play Again button
3. Toggle to daily mode
=> Play Again button will still be visible allowing the player to reset the daily game board

Fix: Hide the play again button when in the daily game mode