### PR TITLE
Fix bug where tiles had delays in resizing when screen was reoriented portrait->landscape

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -227,14 +227,14 @@ a {
   background-color: #ba7a39;
   border: 2px white;
   border-style: dashed;
-  transition-property: 'background-color' border;
+  transition-property: background-color, border;
   transition-duration: .5s;
 }
 
 .rightLetterRightPlace {
   background-color: #6aaa64;
   border: 2px solid white;
-  transition-property: 'background-color' border;
+  transition-property: background-color, border;
   transition-duration: .5s;
 }
 


### PR DESCRIPTION
 - The css value was invalid and meant that there was an unset transition-property on the tile. As this defaults to 'all' the change in the value of the height (height: 15vw;) was not applied immediately
 - This introduced a delay to re-layout of the board if you accidentally or deliberately changed phone from portrait to landscape
 - This PR also fixes this issue when you resize the screen on desktop